### PR TITLE
Update paths to exported esm files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
   ],
   "exports": {
     "node": "./cjs/main.js",
-    "import": "./esm/module.js",
+    "import": "./module.js",
     "require": "./cjs/main.js",
-    "default": "./esm/module.js"
+    "default": "./module.js"
   },
   "type": "module",
   "main": "./cjs/main.js",
-  "module": "./esm/module.js",
+  "module": "./module.js",
   "types": "types.d.ts",
   "devDependencies": {
     "@types/assert": "^1.5.6",


### PR DESCRIPTION
I've been trying to incorporate the new major versions of our packages with the rigs animation_url app. I seems that the paths to esm builds aren't pointing to the right place. 

There are some references to an `esm/` directory which doesn't exist.