### PR TITLE
Include go-sqlparser with upsert walk fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/tablelandnetwork/wasm-sqlparser
 
 go 1.16
 
-require github.com/tablelandnetwork/sqlparser v0.0.0-20230206191942-2a75dd32b7ab
+require github.com/tablelandnetwork/sqlparser v0.0.0-20230328132500-785ebca8e351

--- a/go.sum
+++ b/go.sum
@@ -18,10 +18,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/tablelandnetwork/sqlparser v0.0.0-20221230162331-b318f234cefd h1:AbpyzqlTban/UqJTrotlpWC9q/ePGU4qsrvqjoiLmG4=
-github.com/tablelandnetwork/sqlparser v0.0.0-20221230162331-b318f234cefd/go.mod h1:S+M/v3Q8X+236kQxMQziFcLId2Cscb1LzW06IUVhljE=
-github.com/tablelandnetwork/sqlparser v0.0.0-20230206191942-2a75dd32b7ab h1:B3UYbpNq9bwn+Tm+9GaBBv3UdLkOakDtNd9S+bjDSrA=
-github.com/tablelandnetwork/sqlparser v0.0.0-20230206191942-2a75dd32b7ab/go.mod h1:S+M/v3Q8X+236kQxMQziFcLId2Cscb1LzW06IUVhljE=
+github.com/tablelandnetwork/sqlparser v0.0.0-20230328132500-785ebca8e351 h1:aHuHicCezduOZVQXPXFM5MJ+h73caB2OUvVjGffzIsc=
+github.com/tablelandnetwork/sqlparser v0.0.0-20230328132500-785ebca8e351/go.mod h1:S+M/v3Q8X+236kQxMQziFcLId2Cscb1LzW06IUVhljE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
This includes the fix for a bug in how nodes are walked for upsert commands.