### PR TITLE
Fix publish action by upgrading to >= node 16

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v3
 
       - name: Cache 📦
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -23,12 +23,12 @@ jobs:
             ${{ runner.os }}-
 
       - name: Setup ⬢
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 18
 
       - name: Tag 🏷️
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         id: create-tag
         with:
           github-token: ${{secrets.TEXTILEIO_MACHINE_ACCESS_TOKEN}}
@@ -59,12 +59,11 @@ jobs:
 
       - name: Publish 📦
         id: publish
-        uses: JS-DevTools/npm-publish@v1
+        uses: JS-DevTools/npm-publish@v2
         with:
           token: ${{ secrets.NPM_AUTH_TOKEN }}
           tag: ${{ steps.cond.outputs.value }}
           access: public
-          check-version: true
 
       - name: Release 🚀
         if: steps.publish.outputs.type != 'none'


### PR DESCRIPTION
I was trying to publish a pre-release of the recent fix to the go parser, and the action was failing with an error message of "exited with a status of 127." which seems to be related to some of the outdated action versions using the no longer supported node version 12.
full error is here: https://github.com/tablelandnetwork/wasm-sqlparser/actions/runs/4855608435/jobs/8654324220
This PR upgrades the actions that are using node 12.