### PR TITLE
Include explicit build command in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Install 🔧
         run: npm install
 
+      - name: Build 🔧
+        run: npm run build
+
       - name: Conditional ✅
         id: cond
         uses: haya14busa/action-cond@v1


### PR DESCRIPTION
This fixes #191 by explicitly adding the build step to the workflow instead of just relying on the npm prepublishOnly script.