### PR TITLE
Publish action is still not working for cjs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,18 @@ jobs:
         with:
           tinygo-version: '0.27.0'
 
+      - name: Version 👍
+        id: version-bump
+        uses: jaywcjlove/github-action-package@v1.3.0
+        with:
+          version: ${{ github.event.inputs.release_version }}
+
+      - name: Install 🔧
+        run: npm install
+
+      - name: Build 🔧
+        run: npm run build
+
       - name: Tag 🏷️
         uses: actions/github-script@v6
         id: create-tag
@@ -44,15 +56,6 @@ jobs:
               ref: 'refs/tags/${{ github.event.inputs.release_version }}',
               sha: context.sha
             })
-
-      - name: Version 👍
-        id: version-bump
-        uses: jaywcjlove/github-action-package@v1.3.0
-        with:
-          version: ${{ github.event.inputs.release_version }}
-
-      - name: Install 🔧
-        run: npm install
 
       - name: Conditional ✅
         id: cond

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cache 📦
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
This is another attempt to fix #191 
The addition of tinygo did work to get the wasm build happening, but the cjs directory is not being published to npm.  I tried this in a personal fork and it seems to work, but I can't be sure since my personal account can't publish to the tableland npm namespace.

more details on this issue:
checkout out the npm source https://www.npmjs.com/package/@tableland/sqlparser/v/1.0.6-pre.4?activeTab=code
you'll notice that there is no cjs directory.
However historically it's been included https://www.npmjs.com/package/@tableland/sqlparser/v/1.0.5?activeTab=code
Also if I publish manually from my local env everything works